### PR TITLE
Remove all members from config

### DIFF
--- a/config/HustleInc.yml
+++ b/config/HustleInc.yml
@@ -1,4 +1,4 @@
-# Please insert new items alphabetically.
+#members is intentionally left empty since this means 'all members of the github organization'
 eng:
   members:
 

--- a/config/HustleInc.yml
+++ b/config/HustleInc.yml
@@ -1,31 +1,6 @@
 # Please insert new items alphabetically.
 eng:
   members:
-    - lklots
-    - matteobanerjee
-    - matthewferry
-    - noahsilas
-    - rachelleluyanlee
-    - TJTorola
-    - TylerBrock
-    - ariisrael
-    - isisAnchalee
-    - loganmhb
-    - manuelsabu
-    - esarachan
-    - gellingson
-    - higgins
-    - Lizard381
-    - matthewferry
-    - MatrixFrog
-    - ibash
-    - ninachaubal
-    - richardharrington
-    - caplis
-    - Filip-F
-    - kingdavidmartins
-    - robertbourbonnais
-    - ClaireNeveu
 
   channel: "#engineering"
 


### PR DESCRIPTION
I don't actually know ruby so can someone who does confirm, but if my understanding of the logic inside `github_fetcher.rb` is correct [step 1](https://github.com/HustleInc/seal/blob/master/lib/github_fetcher.rb#L25), [step 2](https://github.com/HustleInc/seal/blob/master/lib/github_fetcher.rb#L84), and [step 3](https://github.com/HustleInc/seal/blob/master/lib/github_fetcher.rb#L54) means the following:

Seal pulls all the PRs from the organization, and then it filters these removing any non-"hidden", hidden in this case meaning closed or no one from the member list is involved, but it also a special case where if members is empty it'll ignore the requirement to have a member involved in the PR, so removing all members from HustleInc.yml should mean we never have to update the list again.