### PR TITLE
[NO-TIX]: Explicitly set members in yaml file to empty array

### DIFF
--- a/config/HustleInc.yml
+++ b/config/HustleInc.yml
@@ -1,6 +1,6 @@
 #members is intentionally left empty since this means 'all members of the github organization'
 eng:
-  members:
+  members: []
 
   channel: "#engineering"
 


### PR DESCRIPTION
It would appear that I made a mistake in https://github.com/HustleInc/seal/pull/2 and that members is being treated as nil, so now I explicitly set it to empty array.