### PR TITLE
Add "needs update" tag from open source projects

### DIFF
--- a/config/HustleInc.yml
+++ b/config/HustleInc.yml
@@ -11,6 +11,7 @@ eng:
 
   exclude_labels:
     - WIP
+    - "needs update"
 
   quotes:
     - ":eggplant:"


### PR DESCRIPTION
When we provide feedback to an author in an open source project, we don't want to merge it, but we also don't want it to anger the seal. (Example: https://github.com/HustleInc/parse-shim/pull/2). By adding a "needs update" tag to the issue and our exclusion list here, we can keep the seal happy.