### PR TITLE
Ignore All Hustle labels

### DIFF
--- a/config/HustleInc.yml
+++ b/config/HustleInc.yml
@@ -12,6 +12,8 @@ eng:
   exclude_labels:
     - WIP
     - "needs update"
+    - "proposal"
+    - "waiting on requirements"
 
   quotes:
     - ":eggplant:"


### PR DESCRIPTION
To avoid PRs which won't be worked on in a bit (like those that are waiting on requirements) I'm adding more labels to the exclude_labels list in seal.